### PR TITLE
change require

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
         "gregwar/captcha": "~1.1",
         "roumen/feed": "^2.10",
         "laravelcollective/bus": "~5.2",
-        "arrilot/laravel-widgets": "^3.3"
+        "arrilot/laravel-widgets": "^3.3",
+        "symfony/dom-crawler": "~3.0"
     },
     "require-dev": {
         "fzaninotto/faker": "^1.5",


### PR DESCRIPTION
composer install --no-dev -o
不会安装dev中的组件，但是Middleware/Pjax.php会调用到dev中的Crawler组件
日志会产生错误信息
