### PR TITLE
lists method in Collection is deprecated in Laravel 5.2

### DIFF
--- a/app/Handlers/Listeners/Notification/SendAppendNotificationHandler.php
+++ b/app/Handlers/Listeners/Notification/SendAppendNotificationHandler.php
@@ -42,7 +42,7 @@ class SendAppendNotificationHandler
     {
         $thread = Thread::findOrFail($append->thread_id);
         $author = Auth::user();
-        $users = $thread->replies()->with('user')->get()->lists('user');
+        $users = $thread->replies()->with('user')->get()->pluck('user');
         // Notify commented user
         app(Notifier::class)->batchNotify(
                     'commented_thread_new_append',

--- a/app/Repositories/Eloquent/Repository.php
+++ b/app/Repositories/Eloquent/Repository.php
@@ -188,7 +188,7 @@ abstract class Repository implements RepositoryInterface, CriteriaInterface
     public function lists($value, $key = null)
     {
         $this->applyCriteria();
-        $lists = $this->model->lists($value, $key);
+        $lists = $this->model->pluck($value, $key);
 
         if (is_array($lists)) {
             return $lists;

--- a/app/Services/Tag/AddTag.php
+++ b/app/Services/Tag/AddTag.php
@@ -60,10 +60,10 @@ class AddTag
     {
         $existing_tags = Tag::whereIn('name', $tags)->get();
 
-        $new_tags = array_diff($tags, $existing_tags->lists('name')->all());
+        $new_tags = array_diff($tags, $existing_tags->pluck('name')->all());
         $new_ids = $this->multiInsert($new_tags);
 
-        return array_merge($existing_tags->lists('id')->all(), $new_ids);
+        return array_merge($existing_tags->pluck('id')->all(), $new_ids);
     }
 
     /**


### PR DESCRIPTION
Since Laravel version 5.2, lists method in Illuminate\Database\Eloquent\Collection is deprecated.

Also see [Laravel API - Collection#method_list](https://laravel.com/api/5.2/Illuminate/Database/Eloquent/Collection.html#method_lists)
